### PR TITLE
call onChange only when function has been provided

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,9 @@ class ReactRanger extends React.Component {
     if (onDrag) {
       onDrag(e)
     }
-    onChange(newValues)
+    if (onChange) {
+      onChange(newValues)
+    }
   }
   onRelease = e => {
     document.removeEventListener('mousemove', this.onDrag)


### PR DESCRIPTION
"onChange" prop is marked as NON-required function, but component always call that function without checking if it exist which causes an error, when no "onChange" function has been provided and user interacts with slider handle.