### PR TITLE
Fix clientX detection on touch devices

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,9 @@ class ReactRanger extends React.Component {
     const { activeHandleIndex } = this.state
     const values = this.getValues()
 
-    const newValue = this.getValueForClientX(e.clientX)
+    const clientX = e.type === 'touchmove' ? e.changedTouches[0].clientX : e.clientX
+
+    const newValue = this.getValueForClientX(clientX)
     const newRoundedValue = this.roundToStep(newValue)
 
     const newValues = [


### PR DESCRIPTION
At the moment, react-ranger component is not usable on touch devices, because e.clientX returns undefined. This PR fixes the problem.

Thanks @jingkai001 for raising the issue https://github.com/react-tools/react-ranger/issues/9 and providing solution