### PR TITLE
Accessibility Improvements

### DIFF
--- a/examples/basic/src/index.js
+++ b/examples/basic/src/index.js
@@ -30,11 +30,12 @@ function App() {
         })}
       >
         {handles.map(({ getHandleProps }) => (
-          <div
+          <button
             {...getHandleProps({
               style: {
-                width: "12px",
-                height: "12px",
+                width: "14px",
+                height: "14px",
+                outline: "none",
                 borderRadius: "100%",
                 background: "linear-gradient(to bottom, #eee 45%, #ddd 55%)",
                 border: "solid 1px #888"

--- a/examples/custom-steps/src/index.js
+++ b/examples/custom-steps/src/index.js
@@ -35,11 +35,12 @@ function App() {
           <div {...getTickProps()}>{value}</div>
         ))}
         {handles.map(({ getHandleProps }) => (
-          <div
+          <button
             {...getHandleProps({
               style: {
-                width: "12px",
-                height: "12px",
+                width: "14px",
+                height: "14px",
+                outline: "none",
                 borderRadius: "100%",
                 background: "linear-gradient(to bottom, #eee 45%, #ddd 55%)",
                 border: "solid 1px #888"

--- a/examples/custom-styles/src/index.js
+++ b/examples/custom-styles/src/index.js
@@ -95,9 +95,18 @@ function App() {
           <Segment {...getSegmentProps()} index={i} />
         ))}
         {handles.map(({ value, active, getHandleProps }) => (
-          <div {...getHandleProps()}>
+          <button
+            {...getHandleProps({
+              style: {
+                appearance: "none",
+                border: "none",
+                background: "transparent",
+                outline: "none"
+              }
+            })}
+          >
             <Handle active={active}>{value}</Handle>
-          </div>
+          </button>
         ))}
       </Track>
       <br />

--- a/examples/multi-range/src/index.js
+++ b/examples/multi-range/src/index.js
@@ -30,11 +30,12 @@ function App() {
         })}
       >
         {handles.map(({ getHandleProps }) => (
-          <div
+          <button
             {...getHandleProps({
               style: {
-                width: "12px",
-                height: "12px",
+                width: "14px",
+                height: "14px",
+                outline: "none",
                 borderRadius: "100%",
                 background: "linear-gradient(to bottom, #eee 45%, #ddd 55%)",
                 border: "solid 1px #888"

--- a/examples/update-on-drag/src/index.js
+++ b/examples/update-on-drag/src/index.js
@@ -30,11 +30,12 @@ function App() {
         })}
       >
         {handles.map(({ getHandleProps }) => (
-          <div
+          <button
             {...getHandleProps({
               style: {
-                width: "12px",
-                height: "12px",
+                width: "14px",
+                height: "14px",
+                outline: "none",
                 borderRadius: "100%",
                 background: "linear-gradient(to bottom, #eee 45%, #ddd 55%)",
                 border: "solid 1px #888"

--- a/src/index.js
+++ b/src/index.js
@@ -233,9 +233,11 @@ export function useRanger({
             handlePress(e, i)
             if (onTouchStart) onTouchStart(e)
           },
-          tabIndex: 1,
+          role: 'slider',
+          'aria-valuemin': min,
+          'aria-valuemax': max,
+          'aria-valuenow': value,
           style: {
-            outline: 0,
             position: 'absolute',
             top: '50%',
             left: `${getPercentageForValue(value)}%`,
@@ -246,7 +248,15 @@ export function useRanger({
           ...rest,
         }),
       })),
-    [activeHandleIndex, getPercentageForValue, handlePress, tempValues, values]
+    [
+      activeHandleIndex,
+      getPercentageForValue,
+      handlePress,
+      min,
+      max,
+      tempValues,
+      values,
+    ]
   )
 
   const getTrackProps = ({ style = {}, ref, ...rest } = {}) => {


### PR DESCRIPTION
(Refers to #16)

Improves A11y support:

- Fix: `getHandleProps` now returns by default: role ('slider'), aria-valuemin, aria-valuemax and aria-valuenow.
- Breaking: Changes `getHandleProps` behavior to **not** set `tabindex` and **not** set `outline` to none. 
  - Updated the examples to use Buttons for handles (since they already are interactive elements and have a tab stop set by default).
- Feature: Added support for keyboard navigation (When a handle is focused, the user can use left/right arrows to change value)

